### PR TITLE
WIP [feature-vme-integration-1674] Add whitelist functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,7 +306,9 @@ AM_CONDITIONAL([USE_SPF], [test x"$use_spf" = x"yes"])
 
 #
 # opendmarc
-# 
+#
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.48.2])
+
 AC_ARG_ENABLE([filter],
               AS_HELP_STRING([--disable-filter],
                              [do not compile the opendmarc filter]),

--- a/opendmarc/Makefile.am
+++ b/opendmarc/Makefile.am
@@ -15,10 +15,10 @@ opendmarc_SOURCES = config.c config.h opendmarc.c opendmarc.h \
 	opendmarc-dstring.c opendmarc-dstring.h \
 	parse.c parse.h test.c test.h util.c util.h
 opendmarc_CC = $(PTHREAD_CC)
-opendmarc_CFLAGS = $(PTHREAD_CFLAGS) 
-opendmarc_CPPFLAGS = $(LIBMILTER_INCDIRS) -I$(srcdir)/../libopendmarc
+opendmarc_CFLAGS = $(PTHREAD_CFLAGS) $(GLIB_CFLAGS)
+opendmarc_CPPFLAGS = $(LIBMILTER_INCDIRS) -I$(srcdir)/../libopendmarc $(GLIB_CFLAGS)
 opendmarc_LDFLAGS = $(LIBMILTER_LIBDIRS) $(PTHREAD_CFLAGS)
-opendmarc_LDADD = ../libopendmarc/libopendmarc.la $(LIBMILTER_LIBS) $(PTHREAD_LIBS) $(LIBRESOLV)
+opendmarc_LDADD = ../libopendmarc/libopendmarc.la $(LIBMILTER_LIBS) $(PTHREAD_LIBS) $(LIBRESOLV) $(GLIB_LIBS)
 
 opendmarc_check_SOURCES = opendmarc-check.c
 opendmarc_check_CPPFLAGS = -I$(srcdir)/../libopendmarc

--- a/opendmarc/opendmarc-config.h
+++ b/opendmarc/opendmarc-config.h
@@ -26,6 +26,7 @@ struct configdef dmarcf_config[] =
 	{ "ChangeRootDirectory",	CONFIG_TYPE_STRING,	FALSE },
 	{ "CopyFailuresTo",		CONFIG_TYPE_STRING,	FALSE },
 	{ "DNSTimeout",			CONFIG_TYPE_INTEGER,	FALSE },
+	{ "DomainWhitelist",	CONFIG_TYPE_STRING,	FALSE },
 	{ "EnableCoredumps",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "FailureReports",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "FailureReportsBcc",		CONFIG_TYPE_STRING,	FALSE },

--- a/opendmarc/opendmarc-config.h
+++ b/opendmarc/opendmarc-config.h
@@ -27,6 +27,7 @@ struct configdef dmarcf_config[] =
 	{ "CopyFailuresTo",		CONFIG_TYPE_STRING,	FALSE },
 	{ "DNSTimeout",			CONFIG_TYPE_INTEGER,	FALSE },
 	{ "DomainWhitelist",	CONFIG_TYPE_STRING,	FALSE },
+	{ "DomainWhitelistFile",	CONFIG_TYPE_STRING, FALSE },
 	{ "EnableCoredumps",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "FailureReports",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "FailureReportsBcc",		CONFIG_TYPE_STRING,	FALSE },

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -120,6 +120,25 @@ Adds the specified recipient to the message's envelope if it fails the DMARC
 evaluation.
 
 .TP
+.I DomainWhitelist (string)
+Require that all domains that appear in the OpenARC Authenticated-Results
+"arc.chain" field (appended by OpenARC "FinalReceiver" mode) also appear in
+this comma-separated list. Matching is case-insensitive. The default list
+is an empty list, meaning no matching is performed.
+
+This list will be concatenated with DomainWhitelistFile (if provided).
+
+.TP
+.I DomainWhitelistFile (string)
+Require that all domains that appear in the OpenARC Authenticated-Results
+"arc.chain" field (appended by OpenARC "FinalReceiver" mode) also appear in
+this file that contains a list of domain names. Entries are separated by a
+newline characters; whitespace is ignored. The default list is an empty
+list, meaning no matching is performed.
+
+This list will be concatenated with DomainWhitelist (if provided).
+
+.TP
 .I DNSTimeout (integer)
 Sets the DNS timeout in seconds.  A value of 0 causes an infinite wait.
 The default is 5.  Ignored if not using an asynchronous resolver package.

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -104,6 +104,18 @@
 #
 # CopyFailuresTo postmaster@localhost
 
+## DomainWhitelist (string)
+##      default (none)
+##
+##  Require that all domains that appear in the OpenARC Authenticated-Results
+##  "arc.chain" field (appended by OpenARC "FinalReceiver" mode) also appear in
+##  this comma-separated list. Matching is case-insensitive. The default list
+##  is an empty list, meaning no matching is performed.
+##
+##  This list will be concatenated with DomainWhitelistFile (if provided).
+##
+# DomainWhiteList example.com
+
 ##  DNSTimeout (integer)
 ##  	default 5
 ## 

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -116,6 +116,19 @@
 ##
 # DomainWhiteList example.com
 
+## DomainWhitelistFile path
+##      default (none)
+##
+##  Require that all domains that appear in the OpenARC Authenticated-Results
+##  "arc.chain" field (appended by OpenARC "FinalReceiver" mode) also appear in
+##  this file that contains a list of domain names. Entries are separated by a
+##  newline characters; whitespace is ignored. The default list is an empty
+##  list, meaning no matching is performed.
+##
+##  This list will be concatenated with DomainWhitelist (if provided).
+##
+# DomainWhitelistFile /usr/local/etc/opendmarc/whitelist.domains
+
 ##  DNSTimeout (integer)
 ##  	default 5
 ## 


### PR DESCRIPTION
This PR is part of the following series of sequentially dependent (stacked) branches and must be merged in order to avoid conflicts. The last branch in the series contains all changes from previous branches. Please review and comment on changes in each PR individually.

The stack includes (sequentially):

feature-vme-integration-1521
feature-vpt-integration-1674
feature-vpt-integration-1675
feature-vpt-integration-1677

This specific PR adds support for whitelist functionality:

- Add DomainWhitelist and DomainWhitelistFile config options
- Loads whitelist file contents using existing parsing routines
- Copies whitelist file contents to a hash for efficiency (implemented with glib hashes)(1)
- Updates man page for DomainWhitelist and DomainWhitelistFile configs

**Notes**
(1) It's anticipated that the whitelist file will be large (thousands of entries) therefore a hash data structure has been used. Using a proven hash implementation is beneficial and therefore the glib library has been added as a dependency. I believe licensing is compatible (glib uses the GNU Lesser General Public License (GNU LGPL) license).
